### PR TITLE
Refactor CaseDataWorker to use threads

### DIFF
--- a/lib/request.rb
+++ b/lib/request.rb
@@ -24,8 +24,6 @@ class Request
       builder.use FaradayMiddleware::FollowRedirects
     end
 
-    puts "GET #{uri} ..."
-
     response = connection.get
     duration = response.env[:duration]
 

--- a/workers/base_worker.rb
+++ b/workers/base_worker.rb
@@ -16,6 +16,10 @@ class BaseWorker
     Request.get("#{url}/query", params: query.merge({ returnCountOnly: true }))[:count]
   end
 
+  def fields_from_feature(url)
+    Request.get(url)[:fields].map { _1[:name] }
+  end
+
   def save_in_cache(cache_key, data, expiration_time = Time.now)
     write_cache(cache_key, data)
     set_expiration(cache_key, Time.now + (CACHE_EXPIRATION_IN_MINUTES * 60))

--- a/workers/case_data_worker.rb
+++ b/workers/case_data_worker.rb
@@ -93,12 +93,6 @@ class CaseDataWorker < BaseWorker
             response = Request.get("#{url}/query", params: query.merge(resultOffset: offset))
             last_item_id = response[:features].last[:attributes][:ObjectId]
             puts "Thread #{Thread.current.name}, offset: #{offset}, results: #{response[:features].count}, last item: #{last_item_id}"
-
-            if response[:features].nil?
-              puts "No results for #{Thread.current.name}"
-              puts response.inspect
-            end
-
             response[:features]
           rescue NoMethodError => error
             Bugsnag.notify(error) do |report|
@@ -116,11 +110,8 @@ class CaseDataWorker < BaseWorker
       end
 
       values = thread_workers.flat_map(&:value)
-      # close all threads
       thread_workers.map(&:join)
-
       raise "Failed to retrieve all results" if values.size < record_total
-
       sorted_results = values.sort_by { _1[:attributes][:ObjectId] }
 
       @case_response_data[:features] = sorted_results

--- a/workers/case_data_worker.rb
+++ b/workers/case_data_worker.rb
@@ -74,39 +74,56 @@ class CaseDataWorker < BaseWorker
 
     puts "Total records: #{record_total}"
 
-    initial_response = Request.get("#{url}/query", params: query)
-    puts "Records in initial response: #{initial_response[:features].count}"
-
-    last_item_id = initial_response[:features].last[:attributes][:ObjectId]
-
-    @case_response_data = { fields: initial_response[:fields], features: [] }
-    @case_response_data[:features].push(*initial_response[:features])
+    @case_response_data = { fields: fields_from_feature(url), features: [] }
 
     # we need to iterate because the maximum record count sent back per
     # request is lower than the absolute total number of record.
     if record_total > maximum_record_count
       puts "Iterating through #{record_total} records to retrieve all ..."
-      while last_item_id < record_total do
-        puts "Offset: #{last_item_id}"
-        begin
-          response = Request.get("#{url}/query", params: query.merge(resultOffset: last_item_id))
-          puts "Results: #{response[:features].count}"
-          @case_response_data[:features].push(*response[:features])
 
-          last_item_id = response[:features].last[:attributes][:ObjectId]
-        rescue NoMethodError => error
-          Bugsnag.notify(error) do |report|
-            report.severity = "error"
+      threads_needed = record_total / maximum_record_count
 
-            report.add_tab(:response, {
-              url: url,
-              last_item_id: last_item_id,
-              record_total: record_total,
-              body: response
-            })
+      thread_workers = (0..threads_needed).map do |thread_number|
+        Thread.new do
+          Thread.current.name = "#{thread_number}"
+
+          offset = maximum_record_count * (thread_number)
+
+          begin
+            response = Request.get("#{url}/query", params: query.merge(resultOffset: offset))
+            last_item_id = response[:features].last[:attributes][:ObjectId]
+            puts "Thread #{Thread.current.name}, offset: #{offset}, results: #{response[:features].count}, last item: #{last_item_id}"
+
+            if response[:features].nil?
+              puts "No results for #{Thread.current.name}"
+              puts response.inspect
+            end
+
+            response[:features]
+          rescue NoMethodError => error
+            Bugsnag.notify(error) do |report|
+              report.severity = "error"
+
+              report.add_tab(:response, {
+                url: url,
+                last_item_id: last_item_id,
+                record_total: record_total,
+                body: response
+              })
+            end
           end
         end
       end
+
+      values = thread_workers.flat_map(&:value)
+      # close all threads
+      thread_workers.map(&:join)
+
+      raise "Failed to retrieve all results" if values.size < record_total
+
+      sorted_results = values.sort_by { _1[:attributes][:ObjectId] }
+
+      @case_response_data[:features] = sorted_results
     else
       puts "All records (#{record_total}) can be fetched in a single request!"
     end
@@ -147,5 +164,8 @@ class CaseDataWorker < BaseWorker
         end
       end
     end
+  rescue => error
+    puts a
+    raise error
   end
 end


### PR DESCRIPTION
Instead of 14+ sequential requests going out (and bound to be more each
week) the total processing time to get all paginated queries done is now
equal to the max response time the single worst query rather than the sum
of all query timings.

In other words, shit fast yo.